### PR TITLE
Explorer will prefer node with higher block height

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ Edit `development.json`
 
 or
 
-  meteor --settings development.json
+	meteor --settings development.json


### PR DESCRIPTION
In the event the primary or secondary node goes down, explorer will use the secondary and tertiary nodes to show data from. In this event, we can expect those nodes may have crashed, and will be out of sync with the network. When they come back online, they would have shown stale data in the explorer. This PR makes the nodes preferred if they have the largest block height - showing the most recent data on the network through explorer.