### PR TITLE
 Hide timestamp for unconfirmed transactions

### DIFF
--- a/imports/ui/components/lasttx/lasttx.html
+++ b/imports/ui/components/lasttx/lasttx.html
@@ -133,7 +133,7 @@
         <img class="transactionTypeImage" src="/img/icons/send.png" />
         <div class="content">
           <div class="header">
-            Unconfirmed | <small>First Seen: {{ts}}</small>
+            Unconfirmed <!-- | <small>First Seen: {{ts}}</small> -->
           </div>
           Transfer
           <p class="transactionAddress value">

--- a/imports/ui/components/tx/tx.html
+++ b/imports/ui/components/tx/tx.html
@@ -45,7 +45,7 @@
             <div class="item"><strong>OTS key</strong> {{ots_key}}</div>
             <div class="item"><strong>Fee</strong> {{tx.tx.fee}} Quanta</div>
             <div class="item"><strong>Size</strong> {{txSize}}</div>            
-            <div class="item"><strong>Status</strong> {{#if isConfirmed}} OK <i class="ui green circle icon"></i> {{ts}} {{else}} Unconfirmed - First Seen: {{ts}}<i class="ui yellow circle icon"></i>{{/if}}</div>
+            <div class="item"><strong>Status</strong> {{#if isConfirmed}} OK <i class="ui green circle icon"></i> {{ts}} {{else}} Unconfirmed <!-- - First Seen: {{ts}} --><i class="ui yellow circle icon"></i>{{/if}}</div>
           </div>
           <div class="ui hidden divider"></div>
         </div>

--- a/imports/ui/components/tx/tx.js
+++ b/imports/ui/components/tx/tx.js
@@ -131,7 +131,9 @@ Template.tx.helpers({
   confirmations() {
     const x = Session.get('status')
     try {
-      return x.node_info.block_height - this.header.block_number + 1
+      let confirmations = x.node_info.block_height - this.header.block_number
+      confirmations += 1
+      return confirmations
     } catch (e) {
       return 0
     }
@@ -140,10 +142,9 @@ Template.tx.helpers({
     if (this.header) {
       const x = moment.unix(this.header.timestamp_seconds)
       return moment(x).format('HH:mm D MMM YYYY')
-    } else {
-      const x = moment.unix(this.timestamp_seconds)
-      return moment(x).format('HH:mm D MMM YYYY')
     }
+    const x = moment.unix(this.timestamp_seconds)
+    return moment(x).format('HH:mm D MMM YYYY')
   },
   color() {
     if (this.tx.transactionType === 'coinbase') {


### PR DESCRIPTION
_timestamp_seconds_ is not sent therefore a ‘first seen’ time is displayed as ‘Timestamp: Invalid time’ (null).  This removes the timestamp from the UI for unconfirmed transactions.