### PR TITLE
Resolve duplicate lastxn display cache bug

### DIFF
--- a/imports/startup/server/cron.js
+++ b/imports/startup/server/cron.js
@@ -84,11 +84,11 @@ const refreshBlocks = () => {
 }
 
 function refreshLasttx() {
-  // First get unconfirmed transactions
-  const unconfirmed = Meteor.wrapAsync(getLatestData)({ filter: 'TRANSACTIONS_UNCONFIRMED', offset: 0, quantity: 10 })
-
-  // Now get confirmed transactions
+  // First get confirmed transactions
   const confirmed = Meteor.wrapAsync(getLatestData)({ filter: 'TRANSACTIONS', offset: 0, quantity: 10 })
+
+  // Now get unconfirmed transactions
+  const unconfirmed = Meteor.wrapAsync(getLatestData)({ filter: 'TRANSACTIONS_UNCONFIRMED', offset: 0, quantity: 10 })
 
   // Merge the two together
   const confirmedTxns = makeTxListHumanReadable(confirmed.transactions, true)


### PR DESCRIPTION
Sometimes transactions would appear in duplicate in the block explorer, one in confirmed state, one in unconfirmed state. This is due to calling the unconfirmed API before the confirmed API when getting transactions to display. If a transaction went from unconfirmed to confirmed in between these two calls, the transaction would show twice on the explorer.

All this PR does is changes the order in which the API calls are made.