### PR TITLE
Add mining stats as per request from @fr1t2

### DIFF
--- a/imports/startup/server/cron.js
+++ b/imports/startup/server/cron.js
@@ -424,3 +424,21 @@ JsonRoutes.add('get', '/api/status', (req, res) => {
     data: response,
   })
 })
+
+JsonRoutes.add('get', '/api/miningstats', (req, res) => {
+  let response = {}
+  const queryResults = homechart.findOne()
+  if (queryResults !== undefined) {
+    response = {
+      block: queryResults.labels[queryResults.labels.length - 1],
+      hashrate: queryResults.datasets[0].data[queryResults.labels.length - 1],
+      difficulty: queryResults.datasets[1].data[queryResults.labels.length - 1],
+      blocktime: queryResults.datasets[2].data[queryResults.labels.length - 1],
+    }
+  } else {
+    response = { found: false, message: 'API error', code: 5003 }
+  }
+  JsonRoutes.sendResult(res, {
+    data: response,
+  })
+})


### PR DESCRIPTION
Adds a server-side JSON route for /api/miningstats giving the latest block’s data from the homepage graph