### PR TITLE
"Nodes" -> "Explorer node active peers"

### DIFF
--- a/imports/ui/components/status/status.html
+++ b/imports/ui/components/status/status.html
@@ -30,7 +30,7 @@
             Connected: {{status.node_info.state}}<br />
             Uptime: {{uptime}}<br />
             {{status.node_info.network_id}}<br />
-            Nodes: {{status.node_info.num_connections}}<br />
+            Explorer node active peers: {{status.node_info.num_connections}}<br />
             Version: <span class="break-word">{{status.node_info.version}}</span>
           </small>
         </div>


### PR DESCRIPTION
Makes it a bit more clear what this number is. The number here isn't the total number of nodes on the network but just the active peer list of the node the explorer is connected to.