### PR TITLE
Prevent invalid txhash -> QRL address conversion

### DIFF
--- a/imports/ui/components/tx/tx.html
+++ b/imports/ui/components/tx/tx.html
@@ -87,8 +87,12 @@
                   {{#if isMultiSigSpend }}
                     <div class="ui large horizontal list wordBreak f-h"><div class="item"><a href="/a/{{multiSigSpendAddress}}">{{multiSigSpendAddress}}</a></div></div>
                   {{else}}
-                    <div class="ui large horizontal list wordBreak f-h"><div class="item"><a href="/a/{{multiSigAddress}}">{{multiSigAddress}}</a></div></div>
-                  {{/if}}
+                        {{#if isMultiSigVote }}
+                        <!-- nil -->
+                        {{else}}
+  <div class="ui large horizontal list wordBreak f-h"><div class="item"><a href="/a/{{multiSigAddress}}">{{multiSigAddress}}</a></div></div>
+                          {{/if}}
+                      {{/if}}
                   {{/if}}
                 </div>
               </div>


### PR DESCRIPTION
Fixes the invalid hashing of a MS_VOTE txhash and presenting it as a QRL multisig address.  This is valid only for MS_CREATE transaction types. HT to @0xFF0 for #406