### PR TITLE
feat: add block to richlist

### DIFF
--- a/imports/ui/components/richlist/richlist.html
+++ b/imports/ui/components/richlist/richlist.html
@@ -11,6 +11,27 @@
       <div class="ui text loader">Loading richlist data...</div>
     </div>
   {{else}}
+    {{#if latestBlock}}
+      <div class="ui info message">
+        <div class="content">
+          <div class="header">
+            <i class="grey info icon"></i>
+            <span class="ui grey text">
+              Data based on block {{latestBlock.number}}
+            </span>
+          </div>
+        </div>
+      </div>
+    {{/if}}
+    {{#if latestBlockError}}
+      <div class="ui warning message">
+        <div class="content">
+          <div class="header">
+            <i class="warning icon"></i>
+            Unable to fetch latest block information</div>
+        </div>
+      </div>
+    {{/if}}
     <table class="ui compact table">
       <thead>
         <tr>

--- a/imports/ui/components/richlist/richlist.js
+++ b/imports/ui/components/richlist/richlist.js
@@ -9,6 +9,10 @@ Template.richlist.onCreated(() => {
   Session.set('richlist', 'loading')
   Session.set('richlistError', false)
   Session.set('richlistData', {})
+  // Add session variables for latest block
+  Session.set('latestBlock', null)
+  Session.set('latestBlockError', false)
+  
   Meteor.call('connectionStatus', (error, result) => {
     if (result.network === 'mainnet') {
       Session.set('network', 'Mainnet')
@@ -16,6 +20,21 @@ Template.richlist.onCreated(() => {
     }
     Session.set('network', 'Testnet')
   })
+  
+  // Fetch latest block information
+  fetch('https://richlist-api.theqrl.org/richlist/latest-block').then((response) => {
+    if (response.status === 200) {
+      response.json().then((blockData) => {
+        Session.set('latestBlock', blockData)
+        Session.set('latestBlockError', false)
+      })
+    } else {
+      Session.set('latestBlockError', true)
+    }
+  }).catch(() => {
+    Session.set('latestBlockError', true)
+  })
+  
   fetch('https://richlist-api.theqrl.org/richlist?page=0').then((response) => {
     if (response.status !== 200) {
       Session.set('richlist', 'error')
@@ -57,6 +76,12 @@ Template.richlist.helpers({
   },
   richlistData() {
     return Session.get('richlistData')
+  },
+  latestBlock() {
+    return Session.get('latestBlock')
+  },
+  latestBlockError() {
+    return Session.get('latestBlockError')
   },
   rank(i) {
     return i + 1


### PR DESCRIPTION
Richlist is based on indexed blocks and may, on occassion, show data some blocks behind the explorer node. This feat adds to the richlist display the block height at which the richlist was generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added status messages above the rich list on Mainnet:
    - When current block data is available, display “Data based on block <number>” with an info icon for clearer context.
    - If block data can’t be retrieved, show a warning with “Unable to fetch latest block information” to indicate partial data.
  - These messages appear alongside the existing rich list table and controls, improving visibility of data freshness without relying solely on loading indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->