### PR TITLE
fix: Richlist full download

### DIFF
--- a/imports/ui/components/richlist/richlist.html
+++ b/imports/ui/components/richlist/richlist.html
@@ -93,9 +93,15 @@
             {{/if}}
           </div>
           
-          <!-- Export Button -->
-          <div class="mt-4 flex justify-end">
+          <!-- Export Buttons -->
+          <div class="mt-4 flex justify-end gap-3">
             <button class="btn-secondary flex items-center hover:bg-qrl-accent/20 hover:border-qrl-accent/50" id="csvExport">
+              <svg class="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd"></path>
+              </svg>
+              Export top {{ totalShown }} to .csv
+            </button>
+            <button class="btn-secondary flex items-center hover:bg-qrl-accent/20 hover:border-qrl-accent/50" id="csvExportAll">
               <svg class="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd"></path>
               </svg>

--- a/imports/ui/components/richlist/richlist.js
+++ b/imports/ui/components/richlist/richlist.js
@@ -118,6 +118,13 @@ Template.richlist.helpers({
     }
     return '0'
   },
+  totalShown() {
+    const data = Session.get('richlistData')
+    if (data && data.length) {
+      return data.length
+    }
+    return 0
+  }
 })
 
 Template.richlist.events({
@@ -170,5 +177,8 @@ Template.richlist.events({
       a.click()
       window.URL.revokeObjectURL(url)
     }
+  },
+  'click #csvExportAll': () => {
+    window.location.href = 'https://richlist-api.theqrl.org/richlist?csv=1'
   },
 })


### PR DESCRIPTION
Fix for #457 

This pull request enhances the export functionality in the Richlist component by adding a new option to export the entire richlist as a CSV file, in addition to the existing option to export only the currently displayed entries. It also introduces a helper to dynamically show the number of entries being exported.

**Export functionality improvements:**

* Added a new export button (`#csvExportAll`) in `richlist.html` that allows users to export the entire richlist to a CSV file, alongside the existing button for exporting only the currently displayed entries. Both buttons now include icons for improved UI clarity.
* Implemented a new event handler in `richlist.js` for the `#csvExportAll` button, which redirects users to the API endpoint to download the full CSV.

**UI and helper updates:**

* Added a `totalShown` helper in `richlist.js` to display the number of currently shown entries in the export button label, making the export scope clear to users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two-button export interface allowing users to export either the top displayed items to CSV or all available data
  * Added a counter displaying the exact number of items included in the selective export option
  * Improved export controls layout with organized button grouping for better UX

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->