### PR TITLE
refactor lasttx and lastblocks 

### DIFF
--- a/imports/startup/server/cron.js
+++ b/imports/startup/server/cron.js
@@ -77,30 +77,45 @@ const refreshBlocks = async () => {
   }
 
   // Fetch current data
-  const current = await Blocks.findOneAsync()
+  const currentDoc = await Blocks.findOneAsync({ _id: 'blocks_singleton' })
+  const existingHeaders = (currentDoc && currentDoc.blockheaders) || []
 
-  // On vanilla build, current will be undefined so we can just insert data
-  if (current === undefined) {
-    await Blocks.insertAsync(response)
+  // Merge new with existing, deduplicating by block number
+  let allHeaders = [...response.blockheaders, ...existingHeaders]
+  const seenNumbers = new Set()
+  allHeaders = allHeaders.filter((bh) => {
+    if (!bh || !bh.header || !bh.header.block_number) return false
+    if (seenNumbers.has(bh.header.block_number)) return false
+    seenNumbers.add(bh.header.block_number)
+    return true
+  })
+
+  // Sort by block number descending
+  allHeaders.sort((a, b) => (b.header.block_number - a.header.block_number))
+
+  // Limit to 100 blocks
+  if (allHeaders.length > 100) {
+    allHeaders = allHeaders.slice(0, 90) // Drop oldest 10 when we hit/exceed limit
+  }
+
+  const merged = {
+    blockheaders: allHeaders,
+  }
+
+  // Only update if data has actually changed to prevent UI flicker
+  let hasChanged = false
+  if (!currentDoc || !currentDoc.blockheaders || currentDoc.blockheaders.length !== merged.blockheaders.length) {
+    hasChanged = true
   } else {
-    // Only update if data has changed.
-    let newData = false
-    _.each(response.blockheaders, (newBlock) => {
-      let thisFound = false
-      _.each(current.blockheaders, (currentBlock) => {
-        if (currentBlock.header.block_number === newBlock.header.block_number) {
-          thisFound = true
-        }
-      })
-      if (thisFound === false) {
-        newData = true
-      }
-    })
-    if (newData === true) {
-      // Clear and update cache as it's changed
-      await Blocks.removeAsync({})
-      await Blocks.insertAsync(response)
+    // Check if newest block number changed
+    if (currentDoc.blockheaders[0].header.block_number !== merged.blockheaders[0].header.block_number) {
+      hasChanged = true
     }
+  }
+
+  if (hasChanged) {
+    // Use upsert with a fixed ID to prevent collection wipe flicker
+    await Blocks.upsertAsync({ _id: 'blocks_singleton' }, { $set: merged })
   }
 
   const lastHeader = response.blockheaders[
@@ -178,55 +193,61 @@ async function refreshLasttx() {
     return
   }
 
-  // Merge the two together
-  const confirmedTxns = await makeTxListHumanReadable(confirmed.transactions, true)
-  const unconfirmedTxns = await makeTxListHumanReadable(
+  // Convert to human readable
+  const newConfirmedTxns = await makeTxListHumanReadable(confirmed.transactions, true)
+  const newUnconfirmedTxns = await makeTxListHumanReadable(
     unconfirmed.transactions_unconfirmed,
     false,
   )
-  const merged = {}
-  merged.transactions = unconfirmedTxns.concat(confirmedTxns)
 
   // Fetch current data
-  const current = await lasttx.findOneAsync()
+  const currentDoc = await lasttx.findOneAsync()
+  const existingTransactions = (currentDoc && currentDoc.transactions) || []
 
-  // On vanilla build, current will be undefined so we can just insert data
-  if (current === undefined) {
-    await lasttx.insertAsync(merged)
+  // Filter out existing confirmed transactions
+  let existingConfirmed = existingTransactions.filter((tx) => tx.tx.confirmed === 'true')
+
+  // Merge new confirmed with existing, deduplicating by hash
+  let allConfirmed = [...newConfirmedTxns, ...existingConfirmed]
+  const seenHashes = new Set()
+  allConfirmed = allConfirmed.filter((tx) => {
+    if (!tx || !tx.tx || !tx.tx.transaction_hash) return false
+    if (seenHashes.has(tx.tx.transaction_hash)) return false
+    seenHashes.add(tx.tx.transaction_hash)
+    return true
+  })
+
+  // Sort by block number descending
+  allConfirmed.sort((a, b) => (b.header.block_number - a.header.block_number))
+
+  // Limit to 100 confirmed transactions
+  if (allConfirmed.length > 100) {
+    allConfirmed = allConfirmed.slice(0, 90) // Drop oldest 10 when we hit/exceed limit
+  }
+
+  const merged = {
+    transactions: newUnconfirmedTxns.concat(allConfirmed),
+  }
+
+  // Only update if data has actually changed to prevent UI flicker
+  let hasChanged = false
+  if (!currentDoc || !currentDoc.transactions || currentDoc.transactions.length !== merged.transactions.length) {
+    hasChanged = true
   } else {
-    // Only update if data has changed.
-    let newData = false
-    _.each(merged.transactions, (newTxn) => {
-      let thisFound = false
-      _.each(current.transactions, (currentTxn) => {
-        // Find a matching pair of transactions by transaction hash
-        if (currentTxn.tx.transaction_hash === newTxn.tx.transaction_hash) {
-          try {
-            // If they both have null header (unconfirmed) there is no change
-            if (currentTxn.header === null && newTxn.header === null) {
-              thisFound = true
-              // If they have same block number, there is also no change.
-            } else if (
-              currentTxn.header.block_number === newTxn.header.block_number
-            ) {
-              thisFound = true
-            }
-          } catch (e) {
-            // Header in cached unconfirmed txn not found, we located a change
-            thisFound = false
-          }
-        }
-      })
-      if (thisFound === false) {
-        newData = true
+    // Check if any transaction hash or confirmed status changed at the same index
+    // (since they are sorted, this is a fast enough check)
+    for (let i = 0; i < merged.transactions.length; i += 1) {
+      if (currentDoc.transactions[i].tx.transaction_hash !== merged.transactions[i].tx.transaction_hash
+          || currentDoc.transactions[i].tx.confirmed !== merged.transactions[i].tx.confirmed) {
+        hasChanged = true
+        break
       }
-    })
-
-    if (newData === true) {
-      // Clear and update cache as it's changed
-      await lasttx.removeAsync({})
-      await lasttx.insertAsync(merged)
     }
+  }
+
+  if (hasChanged) {
+    // Use upsert with a fixed ID to prevent collection wipe flicker
+    await lasttx.upsertAsync({ _id: 'lasttx_singleton' }, { $set: merged })
   }
 }
 
@@ -249,9 +270,8 @@ async function refreshStats() {
 
   console.log('refreshStats: Processing data...')
 
-  // Save status object
-  await status.removeAsync({})
-  await status.insertAsync(res)
+  // Save status object with fixed ID to prevent flickering
+  await status.upsertAsync({ _id: 'status_singleton' }, { $set: res })
 
   // Start modifying data for home chart object
   const chartLineData = {
@@ -319,9 +339,8 @@ async function refreshStats() {
   chartLineData.datasets.push(blockTime)
   chartLineData.datasets.push(movingAverage)
 
-  // Save in mongo
-  await homechart.removeAsync({})
-  await homechart.insertAsync(chartLineData)
+  // Save in mongo with fixed ID to prevent flickering
+  await homechart.upsertAsync({ _id: 'homechart_singleton' }, { $set: chartLineData })
   console.log('refreshStats: Chart data inserted successfully')
 }
 
@@ -342,8 +361,7 @@ const refreshQuantaUsd = async () => {
     return
   }
 
-  await quantausd.removeAsync({})
-  await quantausd.insertAsync({ price })
+  await quantausd.upsertAsync({ _id: 'quantausd_singleton' }, { $set: { price } })
 }
 
 const refreshPeerStats = async () => {
@@ -381,9 +399,8 @@ const refreshPeerStats = async () => {
     )
   })
 
-  // Update mongo collection
-  await peerstats.removeAsync({})
-  await peerstats.insertAsync(response)
+  // Update mongo collection with fixed ID to prevent flickering
+  await peerstats.upsertAsync({ _id: 'peerstats_singleton' }, { $set: response })
 }
 
 // Refresh blocks every 20 seconds

--- a/imports/startup/server/index.js
+++ b/imports/startup/server/index.js
@@ -1448,7 +1448,6 @@ Meteor.methods({
 
   async status() {
     console.log('status method called')
-    // avoid blocking other method calls from same client - *may need to remove for production*
     this.unblock()
     // asynchronous call to API
     const response = await getStatsAsync({})
@@ -1457,7 +1456,6 @@ Meteor.methods({
 
   async lastblocks() {
     console.log('lastblocks method called')
-    // avoid blocking other method calls from same client - *may need to remove for production*
     this.unblock()
     // asynchronous call to API
     const response = await getLatestDataAsync({
@@ -1470,7 +1468,6 @@ Meteor.methods({
 
   async lastunconfirmedtx() {
     console.log('lastunconfirmedtx method called')
-    // avoid blocking other method calls from same client - *may need to remove for production*
     this.unblock()
     // asynchronous call to API
     const response = await getLatestDataAsync({
@@ -1489,7 +1486,6 @@ Meteor.methods({
   async txhash(txId) {
     check(txId, String)
     console.log(`txhash method called for: ${txId}`)
-    // avoid blocking other method calls from same client - *may need to remove for production*
     this.unblock()
     if (!(Match.test(txId, String) && txId.length === 64)) {
       const errorCode = 400
@@ -1541,8 +1537,7 @@ Meteor.methods({
       console.log('Throwing invalid block number error')
       throw new Meteor.Error(errorCode, errorMessage)
     } else {
-      // avoid blocking other method calls from same client - *may need to remove for production*
-      this.unblock()
+        this.unblock()
       // first check this is not cached
       const queryResults = await blockData.findOneAsync({ blockId })
       if (queryResults !== undefined) {
@@ -1996,6 +1991,13 @@ Meteor.methods({
     const firstNode = activeNodes[0].substring(0, 7)
     const res = { colour: 'green', network: firstNode }
     return res
+  },
+
+  async lasttxPaged() {
+    console.log('lasttxPaged method called')
+    this.unblock()
+    const res = await lasttx.findOneAsync()
+    return res || { transactions: [] }
   },
 })
 

--- a/imports/ui/components/lastblocks/lastblocks.html
+++ b/imports/ui/components/lastblocks/lastblocks.html
@@ -2,10 +2,41 @@
   <div class="space-y-6">
     <div class="flex items-center justify-between">
       <h4 class="text-2xl font-bold text-qrl-text">Latest Blocks</h4>
+      {{#if isHome}}
       <a href="/lastblocks" class="text-sm text-qrl-accent hover:text-qrl-accent/80 transition-colors font-medium">
-        View All &rarr;
+        View More &rarr;
       </a>
+      {{/if}}
     </div>
+
+    {{#if isLastBlocks}}
+    <div class="card">
+      <div class="flex flex-col sm:flex-row items-center justify-between space-y-4 sm:space-y-0">
+        <div class="flex items-center space-x-2">
+          <label for="paginator" class="text-sm text-qrl-text-secondary">Page</label>
+          <input type="text" placeholder="{{currentPage}}" id="paginator" class="w-16 px-2 py-1 bg-qrl-secondary border border-qrl-border rounded text-qrl-text text-center">
+          <span class="text-sm text-qrl-text-secondary">of {{totalPages}}</span>
+        </div>
+        <div class="flex items-center space-x-1 pagination-buttons">
+          {{#if pback}}
+            <button qrl-data="back" class="px-3 py-1 text-sm border border-qrl-border rounded hover:bg-qrl-secondary text-qrl-text">
+              &larr;
+            </button>
+          {{/if}}
+          {{#each pages}}
+            <button qrl-page="{{this.number}}" class="page-btn px-3 py-1 text-sm border border-qrl-border rounded hover:bg-qrl-secondary text-qrl-text {{#if isActive}}bg-qrl-accent text-qrl-primary{{/if}}">
+              {{this.number}}
+            </button>
+          {{/each}}
+          {{#if pforward}}
+            <button qrl-data="forward" class="px-3 py-1 text-sm border border-qrl-border rounded hover:bg-qrl-secondary text-qrl-text">
+              &rarr;
+            </button>
+          {{/if}}
+        </div>
+      </div>
+    </div>
+    {{/if}}
 
     {{#with lastblocks}}
       {{#if error}}
@@ -24,7 +55,7 @@
         </div>
       {{else}}
         <div class="space-y-3">
-          {{#each lastblocks.blockheaders}}
+          {{#each pagedBlockheaders}}
             <div class="card transactionRecord border-type-sent hover:border-qrl-accent/50 cursor-pointer min-h-44 sm:h-48 flex flex-col lastBlocks p-4"
                  data-dest="{{this.header.block_number}}">
 
@@ -52,7 +83,7 @@
                     </div>
                     <div class="flex flex-col">
                       <span class="text-xs text-qrl-text-secondary mb-1">Quanta</span>
-                      <span class="text-sm text-qrl-text font-mono">{{transacted(this.totalTransacted)}}</span>
+                      <span class="text-sm text-qrl-text font-mono">{{transacted totalTransacted}}</span>
                     </div>
                     <div class="flex flex-col">
                       <span class="text-xs text-qrl-text-secondary mb-1">Interval</span>
@@ -72,12 +103,14 @@
           {{/each}}
         </div>
 
-        <!-- View All Blocks Link -->
+        <!-- View More Blocks Link (Home only) -->
+        {{#if isHome}}
         <div class="text-center pt-2">
           <a href="/lastblocks" class="btn-secondary inline-flex items-center text-sm">
-            View All Blocks &rarr;
+            View More Blocks &rarr;
           </a>
         </div>
+        {{/if}}
       {{/if}}
     {{/with}}
   </div>

--- a/imports/ui/components/lastblocks/lastblocks.js
+++ b/imports/ui/components/lastblocks/lastblocks.js
@@ -31,23 +31,93 @@ Template.lastblocks.onCreated(() => {
 })
 
 Template.lastblocks.helpers({
+  isHome() {
+    return FlowRouter.getRouteName() === 'App.home'
+  },
+  isLastBlocks() {
+    return FlowRouter.getRouteName() === 'Lastblocks.home'
+  },
   lastblocks() {
-    const res = Blocks.findOne()
-    if (res) {
-      res.blockheaders = res.blockheaders.reverse()
-      const editedBlockheaders = []
-      res.blockheaders.forEach((bh) => {
-        editedBlockheaders.push(addHex(bh))
-      })
-      res.blockheaders = editedBlockheaders
-    }
+    const res = Blocks.findOne({ _id: 'blocks_singleton' })
     return res
   },
+  pagedBlockheaders() {
+    const res = Blocks.findOne({ _id: 'blocks_singleton' })
+    if (res && res.blockheaders) {
+      let { blockheaders } = res
+      
+      // Filter out invalid entries
+      blockheaders = blockheaders.filter(bh => bh && bh.header)
+
+      if (FlowRouter.getRouteName() === 'App.home') {
+        return blockheaders.slice(0, 10).map(bh => addHex(bh))
+      }
+
+      // Pagination for /lastblocks using query params
+      const itemsPerPage = 10
+      const activePage = parseInt(FlowRouter.getQueryParam('page'), 10) || 1
+      const startIndex = (activePage - 1) * itemsPerPage
+      return blockheaders.slice(startIndex, startIndex + itemsPerPage).map(bh => addHex(bh))
+    }
+    return []
+  },
+  // Pagination helpers using query params
+  currentPage() {
+    return parseInt(FlowRouter.getQueryParam('page'), 10) || 1
+  },
+  totalPages() {
+    const res = Blocks.findOne({ _id: 'blocks_singleton' })
+    if (res && res.blockheaders) {
+      return Math.ceil(res.blockheaders.length / 10) || 1
+    }
+    return 1
+  },
+  pages() {
+    const res = Blocks.findOne({ _id: 'blocks_singleton' })
+    if (res && res.blockheaders) {
+      const totalPages = Math.ceil(res.blockheaders.length / 10)
+      const pages = []
+      for (let i = 1; i <= totalPages; i += 1) {
+        pages.push({
+          number: i,
+          isActive: (parseInt(FlowRouter.getQueryParam('page'), 10) || 1) === i,
+        })
+      }
+      
+      const currentPage = parseInt(FlowRouter.getQueryParam('page'), 10) || 1
+      if (pages.length <= 10) {
+        return pages
+      }
+      if (currentPage <= 5) {
+        return pages.slice(0, 9)
+      }
+      if (currentPage > pages.length - 5) {
+        return pages.slice(pages.length - 9)
+      }
+      return pages.slice(currentPage - 5, currentPage + 4)
+    }
+    return []
+  },
+  pback() {
+    const currentPage = parseInt(FlowRouter.getQueryParam('page'), 10) || 1
+    return currentPage > 1
+  },
+  pforward() {
+    const res = Blocks.findOne({ _id: 'blocks_singleton' })
+    if (res && res.blockheaders) {
+      const totalPages = Math.ceil(res.blockheaders.length / 10)
+      const currentPage = parseInt(FlowRouter.getQueryParam('page'), 10) || 1
+      return currentPage < totalPages
+    }
+    return false
+  },
   ts() {
+    if (!this.header) return ''
     const x = moment.unix(this.header.timestamp_seconds)
     return moment(x).format('HH:mm:ss D MMM YYYY')
   },
   tsReadable() {
+    if (!this.header) return ''
     const x = moment.unix(this.header.timestamp_seconds)
     return moment(x).fromNow()
   },
@@ -75,7 +145,7 @@ Template.lastblocks.helpers({
   },
   interval() {
     // Get the current block data
-    const res = Blocks.findOne()
+    const res = Blocks.findOne({ _id: 'blocks_singleton' })
     if (!res || !res.blockheaders) {
       return 'N/A'
     }
@@ -85,13 +155,12 @@ Template.lastblocks.helpers({
       block.header.block_number === this.header.block_number
     ))
 
-    if (currentBlockIndex === -1 || currentBlockIndex === 0) {
-      // If this is the first block (index 0) or not found, return N/A
+    // Note: in descending list, previous block (lower number) is at HIGHER index
+    if (currentBlockIndex === -1 || currentBlockIndex === res.blockheaders.length - 1) {
       return 'N/A'
     }
 
-    // Get the previous block (lower block number, earlier timestamp)
-    const previousBlock = res.blockheaders[currentBlockIndex - 1]
+    const previousBlock = res.blockheaders[currentBlockIndex + 1]
 
     if (!previousBlock) {
       return 'N/A'
@@ -119,15 +188,8 @@ Template.lastblocks.helpers({
     return r
   },
   numberTransactions() {
+    if (!this.transaction_count || !this.transaction_count.count) return 0
     const x = this.transaction_count.count
-    //     UNKNOWN = 0;
-    //     TRANSFER = 1;
-    //     STAKE = 2;
-    //     DESTAKE = 3;
-    //     COINBASE = 4;
-    //     LATTICE = 5;
-    //     DUPLICATE = 6;
-    //     VOTE = 7;
     return sumValues(x)
   },
 })
@@ -140,5 +202,44 @@ Template.lastblocks.events({
     const route = event.currentTarget.getAttribute('data-dest')
     FlowRouter.go(`/block/${route}`)
     window.scrollTo(0, 0)
+  },
+  'click .page-btn': (event) => {
+    const newPage = parseInt(event.target.getAttribute('qrl-page'), 10)
+    if (newPage) {
+      FlowRouter.setQueryParams({ page: newPage })
+      window.scrollTo(0, 0)
+    }
+  },
+  'click button[qrl-data]': (event) => {
+    const action = event.target.getAttribute('qrl-data')
+    const currentPage = parseInt(FlowRouter.getQueryParam('page'), 10) || 1
+    const res = Blocks.findOne({ _id: 'blocks_singleton' })
+    if (res && res.blockheaders) {
+      const totalPages = Math.ceil(res.blockheaders.length / 10) || 1
+      let newPage = currentPage
+      if (action === 'forward') {
+        newPage += 1
+      } else if (action === 'back') {
+        newPage -= 1
+      }
+      if (newPage <= totalPages && newPage > 0) {
+        FlowRouter.setQueryParams({ page: newPage })
+        window.scrollTo(0, 0)
+      }
+    }
+  },
+  'keyup #paginator': (event) => {
+    if (event.which === 13) {
+      let page = parseInt(event.target.value, 10)
+      const res = Blocks.findOne({ _id: 'blocks_singleton' })
+      if (res && res.blockheaders) {
+        const totalPages = Math.ceil(res.blockheaders.length / 10) || 1
+        if (page < 1) page = 1
+        if (page > totalPages) page = totalPages
+        FlowRouter.setQueryParams({ page })
+        event.target.value = ''
+        window.scrollTo(0, 0)
+      }
+    }
   },
 })

--- a/imports/ui/components/lasttx/lasttx.html
+++ b/imports/ui/components/lasttx/lasttx.html
@@ -2,10 +2,41 @@
   <div class="space-y-6">
     <div class="flex items-center justify-between">
       <h4 class="text-2xl font-bold text-qrl-text">Latest Transactions</h4>
+      {{#if isHome}}
       <a href="/lasttx" class="text-sm text-qrl-accent hover:text-qrl-accent/80 transition-colors font-medium">
-        View All &rarr;
+        View More &rarr;
       </a>
+      {{/if}}
     </div>
+
+    {{#if isLastTx}}
+    <div class="card">
+      <div class="flex flex-col sm:flex-row items-center justify-between space-y-4 sm:space-y-0">
+        <div class="flex items-center space-x-2">
+          <label for="paginator" class="text-sm text-qrl-text-secondary">Page</label>
+          <input type="text" placeholder="{{currentPage}}" id="paginator" class="w-16 px-2 py-1 bg-qrl-secondary border border-qrl-border rounded text-qrl-text text-center">
+          <span class="text-sm text-qrl-text-secondary">of {{totalPages}}</span>
+        </div>
+        <div class="flex items-center space-x-1 pagination-buttons">
+          {{#if pback}}
+            <button qrl-data="back" class="px-3 py-1 text-sm border border-qrl-border rounded hover:bg-qrl-secondary text-qrl-text">
+              &larr;
+            </button>
+          {{/if}}
+          {{#each pages}}
+            <button qrl-page="{{this.number}}" class="page-btn px-3 py-1 text-sm border border-qrl-border rounded hover:bg-qrl-secondary text-qrl-text {{#if isActive}}bg-qrl-accent text-qrl-primary{{/if}}">
+              {{this.number}}
+            </button>
+          {{/each}}
+          {{#if pforward}}
+            <button qrl-data="forward" class="px-3 py-1 text-sm border border-qrl-border rounded hover:bg-qrl-secondary text-qrl-text">
+              &rarr;
+            </button>
+          {{/if}}
+        </div>
+      </div>
+    </div>
+    {{/if}}
 
     {{#with lasttx}} {{#if zeroCheck}}
     <div class="card border-red-500/30 bg-red-500/10">
@@ -37,7 +68,7 @@
     </div>
     {{else}}
     <div class="space-y-3">
-      {{#each transactions}}
+      {{#each pagedTransactions}}
       <!-- All Transactions (Confirmed and Unconfirmed) -->
       <div
         class="card hover:border-qrl-accent/50 min-h-44 sm:h-48 flex flex-col transactionRecord cursor-pointer p-4 {{borderTypeClass this.tx.transactionType}}"
@@ -211,12 +242,15 @@
       {{/each}}
     </div>
 
-    <!-- View All Transactions Link -->
+    <!-- View More Transactions Link (Home only) -->
+    {{#if isHome}}
     <div class="text-center pt-2">
       <a href="/lasttx" class="btn-secondary inline-flex items-center text-sm">
-        View All Transactions &rarr;
+        View More Transactions &rarr;
       </a>
     </div>
+    {{/if}}
+
     {{/if}} {{/with}}
   </div>
 </template>

--- a/imports/ui/components/lasttx/lasttx.js
+++ b/imports/ui/components/lasttx/lasttx.js
@@ -29,6 +29,74 @@ Template.lasttx.onCreated(() => {
 })
 
 Template.lasttx.helpers({
+  isHome() {
+    return FlowRouter.getRouteName() === 'App.home'
+  },
+  isLastTx() {
+    return FlowRouter.getRouteName() === 'Lasttx.home'
+  },
+  currentPage() {
+    const page = parseInt(FlowRouter.getQueryParam('page'), 10) || 1
+    return page
+  },
+  totalPages() {
+    const res = lasttx.findOne({ _id: 'lasttx_singleton' })
+    if (res && res.transactions) {
+      return Math.ceil(res.transactions.length / 10) || 1
+    }
+    return 1
+  },
+  pagedTransactions() {
+    const res = lasttx.findOne({ _id: 'lasttx_singleton' })
+    if (res && res.transactions) {
+      if (FlowRouter.getRouteName() === 'App.home') {
+        return res.transactions.slice(0, 10)
+      }
+      const page = parseInt(FlowRouter.getQueryParam('page'), 10) || 1
+      const start = (page - 1) * 10
+      return res.transactions.slice(start, start + 10)
+    }
+    return []
+  },
+  pages() {
+    const res = lasttx.findOne({ _id: 'lasttx_singleton' })
+    if (res && res.transactions) {
+      const totalPages = Math.ceil(res.transactions.length / 10)
+      const pages = []
+      for (let i = 1; i <= totalPages; i += 1) {
+        pages.push({
+          number: i,
+          isActive: (parseInt(FlowRouter.getQueryParam('page'), 10) || 1) === i,
+        })
+      }
+      // Simple pagination: show current page and a few around it if many
+      const currentPage = parseInt(FlowRouter.getQueryParam('page'), 10) || 1
+      if (pages.length <= 10) {
+        return pages
+      }
+      if (currentPage <= 5) {
+        return pages.slice(0, 9)
+      }
+      if (currentPage > pages.length - 5) {
+        return pages.slice(pages.length - 9)
+      }
+      return pages.slice(currentPage - 5, currentPage + 4)
+    }
+    return []
+  },
+  pback() {
+    const currentPage = parseInt(FlowRouter.getQueryParam('page'), 10) || 1
+    return currentPage > 1
+  },
+  pforward() {
+    const res = lasttx.findOne({ _id: 'lasttx_singleton' })
+    if (res && res.transactions) {
+      const totalPages = Math.ceil(res.transactions.length / 10)
+      const currentPage = parseInt(FlowRouter.getQueryParam('page'), 10) || 1
+      return currentPage < totalPages
+    }
+    return false
+  },
   multipleDestinations() {
     if (this.explorer.outputs) {
       if (this.explorer.outputs.length > 1) {
@@ -38,7 +106,7 @@ Template.lasttx.helpers({
     return false
   },
   lasttx() {
-    const res = lasttx.findOne()
+    const res = lasttx.findOne({ _id: 'lasttx_singleton' })
     return res
   },
   fromAddress() {
@@ -79,13 +147,12 @@ Template.lasttx.helpers({
   },
   zeroCheck() {
     let ret = false
-    const x = lasttx.findOne()
+    const x = lasttx.findOne({ _id: 'lasttx_singleton' })
     if (x) {
-      if (x.length === 0) {
+      if (x.transactions && x.transactions.length === 0) {
         ret = true
       }
-    }
-    if (x === undefined) {
+    } else {
       ret = true
     }
     return ret
@@ -284,6 +351,44 @@ Template.lasttx.events({
     if (hashElement) {
       const transactionHash = hashElement.getAttribute('data-full-text')
       FlowRouter.go(`/tx/${transactionHash}`)
+      window.scrollTo(0, 0)
+    }
+  },
+  'keypress #paginator': (event) => {
+    if (event.keyCode === 13) {
+      const x = parseInt(document.getElementById('paginator').value, 10)
+      const res = lasttx.findOne({ _id: 'lasttx_singleton' })
+      if (res && res.transactions) {
+        const totalPages = Math.ceil(res.transactions.length / 10) || 1
+        if (x <= totalPages && x > 0) {
+          FlowRouter.setQueryParams({ page: x })
+          window.scrollTo(0, 0)
+        }
+      }
+    }
+  },
+  'click button[qrl-data]': (event) => {
+    const action = event.currentTarget.getAttribute('qrl-data')
+    const currentPage = parseInt(FlowRouter.getQueryParam('page'), 10) || 1
+    const res = lasttx.findOne({ _id: 'lasttx_singleton' })
+    if (res && res.transactions) {
+      const totalPages = Math.ceil(res.transactions.length / 10) || 1
+      let newPage = currentPage
+      if (action === 'forward') {
+        newPage += 1
+      } else if (action === 'back') {
+        newPage -= 1
+      }
+      if (newPage <= totalPages && newPage > 0) {
+        FlowRouter.setQueryParams({ page: newPage })
+        window.scrollTo(0, 0)
+      }
+    }
+  },
+  'click .page-btn': (event) => {
+    const newPage = parseInt(event.currentTarget.getAttribute('qrl-page'), 10)
+    if (newPage) {
+      FlowRouter.setQueryParams({ page: newPage })
       window.scrollTo(0, 0)
     }
   },

--- a/imports/ui/components/peerstats/peerstats.js
+++ b/imports/ui/components/peerstats/peerstats.js
@@ -7,7 +7,7 @@ Template.peerstats.onCreated(() => {
 
 Template.peerstats.helpers({
   peerstats() {
-    const res = peerstats.findOne()
+    const res = peerstats.findOne({ _id: 'peerstats_singleton' })
     return res
   },
   ts() {
@@ -16,9 +16,14 @@ Template.peerstats.helpers({
   },
   zeroCheck() {
     let ret = false
-    const x = peerstats.findOne()
-    if (x) { if (x.length === 0) { ret = true } }
-    if (x === undefined) { ret = true }
+    const x = peerstats.findOne({ _id: 'peerstats_singleton' })
+    if (x) {
+      if (x.peers_stat && x.peers_stat.length === 0) {
+        ret = true
+      }
+    } else {
+      ret = true
+    }
     return ret
   },
 })

--- a/imports/ui/components/status/status.js
+++ b/imports/ui/components/status/status.js
@@ -61,15 +61,15 @@ Template.status.onDestroyed(function () {
 
 Template.status.helpers({
   quantaUsd() {
-    const quote = quantausd.findOne()
+    const quote = quantausd.findOne({ _id: 'quantausd_singleton' })
     if (!quote || !Number.isFinite(quote.price)) {
       return '--'
     }
     return currencyFormatter.format(quote.price)
   },
   marketCap() {
-    const x = Session.get('explorer-status')
-    const quote = quantausd.findOne()
+    const x = status.findOne({ _id: 'status_singleton' })
+    const quote = quantausd.findOne({ _id: 'quantausd_singleton' })
 
     if (!x || !quote || !Number.isFinite(quote.price)) {
       return '--'
@@ -84,16 +84,18 @@ Template.status.helpers({
     return currencyFormatter.format(marketCap)
   },
   status() {
-    const response = Session.get('explorer-status')
+    const response = status.findOne({ _id: 'status_singleton' })
     return response
   },
   uptime() {
-    const x = Session.get('explorer-status')
+    const x = status.findOne({ _id: 'status_singleton' })
+    if (!x) return '--'
     const uptime = moment.duration(parseInt(x.uptime_network, 10), 'seconds')
     return moment.duration(uptime, 'seconds').format('D[d] h[h] m[min]')
   },
   emission() {
-    const x = Session.get('explorer-status')
+    const x = status.findOne({ _id: 'status_singleton' })
+    if (!x) return '--'
     let r = 'Undetermined'
     try {
       // eslint-disable-next-line
@@ -104,7 +106,8 @@ Template.status.helpers({
     return r
   },
   emission_raw() {
-    const x = Session.get('explorer-status')
+    const x = status.findOne({ _id: 'status_singleton' })
+    if (!x) return '--'
     let r = '?'
     try {
       r = (parseFloat(x.coins_emitted) / SHOR_PER_QUANTA)
@@ -116,7 +119,8 @@ Template.status.helpers({
     return r
   },
   totalSupply() {
-    const x = Session.get('explorer-status')
+    const x = status.findOne({ _id: 'status_singleton' })
+    if (!x) return '--'
     let r = 'Undetermined'
     try {
       r = supplyFormatter.format(parseFloat(x.coins_total_supply))
@@ -136,7 +140,8 @@ Template.status.helpers({
     return r
   },
   unmined() {
-    const x = Session.get('explorer-status')
+    const x = status.findOne({ _id: 'status_singleton' })
+    if (!x) return '--'
     let r = 'Undetermined'
     try {
       r = parseFloat(x.coins_total_supply) - (parseFloat(x.coins_emitted) / SHOR_PER_QUANTA)
@@ -148,7 +153,8 @@ Template.status.helpers({
     return r
   },
   max_block_index() {
-    const x = Session.get('explorer-status')
+    const x = status.findOne({ _id: 'status_singleton' })
+    if (!x) return '--'
     let r = 'Undetermined'
     try {
       r = x.node_info.block_height
@@ -158,7 +164,7 @@ Template.status.helpers({
     return r
   },
   timeSinceLastBlock() {
-    const blocksDocument = Blocks.findOne()
+    const blocksDocument = Blocks.findOne({ _id: 'blocks_singleton' })
     if (!blocksDocument || !Array.isArray(blocksDocument.blockheaders) || blocksDocument.blockheaders.length === 0) {
       return '--'
     }

--- a/imports/ui/pages/home/home.js
+++ b/imports/ui/pages/home/home.js
@@ -507,7 +507,7 @@ async function updateChart(newData) {
 }
 
 async function renderChart() {
-  const chartLineData = homechart.findOne()
+  const chartLineData = homechart.findOne({ _id: 'homechart_singleton' })
 
   if (!chartLineData) {
     return


### PR DESCRIPTION
This pull request introduces significant improvements to the server-side caching and UI pagination for block and transaction data. The main changes include switching to upsert operations with fixed singleton IDs for Mongo collections to reduce UI flicker, adding paginated display and navigation for blocks in the UI, and updating helper logic for block intervals and transaction counts. These updates improve performance, reliability, and user experience.

Closes #475 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination controls to recent blocks and transactions on the home page with page navigation buttons.
  * New endpoint for retrieving paginated transaction data.

* **Bug Fixes**
  * Reduced UI flicker during data updates through improved data handling and change detection.
  * Enhanced stability of block and transaction data display.

* **UI Updates**
  * Replaced "View All" links with "View More" for consistency across blocks and transactions sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->